### PR TITLE
fix typo MATCHED_AMBIG_U_OUSLY

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -93,7 +93,7 @@ Mögliche Ursachen können sein:
 #### Was ist zu tun?
 1. In OSM sollte die name-Eigenschaft erfasst werden. Idealerweise verfügt die erfassende Person über lokales Wissen, um die tatsächlich gebräuchliche Schreibweise zu erfassen. Aus dem Haltestellenregister sollten die Daten nur übernommen werden, wenn alle sonstigen Match-Kriterien eine korrekte Zuordnung vermuten lassen.
 
-### MATCHED_AMBIGOUSLY
+### MATCHED_AMBIGUOUSLY
 In OSM existieren mehrere Haltestellen (üblicherweise Steige in unterschiedliche Fahrtrichtungen), im Haltestellenregister jedoch nur einer mit gleicher DHIHD. 
 
 #### Mögliche Ursachen

--- a/osm_stop_matcher/StatisticsUpdater.py
+++ b/osm_stop_matcher/StatisticsUpdater.py
@@ -61,7 +61,7 @@ class StatisticsUpdater():
 							WHERE globaleID IN (SELECT ifopt_id FROM matches m WHERE rating < 0.002)""")
 		self.db.execute("""UPDATE haltestellen_unified SET match_state='MATCHED_THOUGH_REVERSED_DIR' 
 							WHERE globaleID IN (SELECT ifopt_id FROM matches m WHERE successor_rating =-1)""")
-		self.db.execute("""UPDATE haltestellen_unified SET match_state='MATCHED_AMBIGOUSLY' 
+		self.db.execute("""UPDATE haltestellen_unified SET match_state='MATCHED_AMBIGUOUSLY' 
 							WHERE globaleID IN (SELECT ifopt_id FROM matches GROUP BY ifopt_id HAVING count(*)>1)""")
 		self.db.execute("""UPDATE haltestellen_unified SET match_state='NO_MATCH' 
 							WHERE globaleID NOT IN (SELECT ifopt_id FROM matches);""")


### PR DESCRIPTION
This PR fixes #16. It renames MATCHED_AMBIGOUSLY into MATCHED_AMBIGUOUSLY